### PR TITLE
Add app-review action to fallback URL

### DIFF
--- a/Source/ReviewManager.swift
+++ b/Source/ReviewManager.swift
@@ -51,10 +51,10 @@ public class ReviewManager {
     public func openAppStore(appId: String)
     {
         if #available(iOS 10.0, *) {
-            UIApplication.shared.open(URL(string: "https://itunes.apple.com/app/id\(appId)")!, options: [:], completionHandler: nil)
+            UIApplication.shared.open(URL(string: "https://itunes.apple.com/app/id\(appId)?action=write-review")!, options: [:], completionHandler: nil)
         } else {
             // Fallback on earlier versions
-            UIApplication.shared.openURL(URL(string: "https://itunes.apple.com/app/id\(appId)")!)
+            UIApplication.shared.openURL(URL(string: "https://itunes.apple.com/app/id\(appId)?action=write-review")!)
         }
     }
     


### PR DESCRIPTION
See https://developer.apple.com/documentation/storekit/skstorereviewcontroller/2851536-requestreview
> To automatically open a page on which users can write a review in the App Store, append the query parameter action=write-review to your product URL.